### PR TITLE
Render nav above geojson visualization

### DIFF
--- a/src/components/header/header.scss
+++ b/src/components/header/header.scss
@@ -1,7 +1,7 @@
 header {
   background-color: white;
   padding: 0;
-  z-index: 100;
+  z-index: 10000;
   position: relative;
   margin-bottom: 75px;
 


### PR DESCRIPTION
The Geojson Visualization on the dataset details page currently appears above navigation bar. The nav bar should show up on top of/over the map.

https://github.com/SmartColumbusOS/discovery/issues/7